### PR TITLE
Feature | Add Map.replace function

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -130,4 +130,14 @@ export default {
   // Returns all values from map
   // values(map) :: [value]
   values: _.values,
+
+  // Alters the value stored under key to value, but only if the entry key already
+  // exists in the object
+  // replace(map, key, value) :: map
+  replace(map, key, value) {
+    if (this.hasKey(map, key)) {
+      return {...map, [key]: value};
+    }
+    return map;
+  },
 };

--- a/test/map.js
+++ b/test/map.js
@@ -273,4 +273,18 @@ describe("Map", () => {
       assertEq(expected, actual);
     });
   });
+
+  describe("replace", () => {
+    test("should update a value under a pre-existing key", () => {
+      const expected = {a: 2, b: 2};
+      const actual = Map.replace({a: 1, b: 2}, "a", 2);
+      assertEq(expected, actual);
+    });
+
+    test("should make no change if the key is not present in the object", () => {
+      const expected = {a: 1, b: 2};
+      const actual = Map.replace({a: 1, b: 2}, "c", 3);
+      assertEq(expected, actual);
+    });
+  });
 });


### PR DESCRIPTION
From the `@doc` for the Elixir `Map.replace/3` function:

```elixir
@doc """
Alters the value stored under key to value, but only if the entry key already
exists in map.


    iex> Map.replace(%{a: 1}, :b, 2)
    %{a: 1}
    iex> Map.replace(%{a: 1, b: 2}, :a, 3)
    %{a: 3, b: 2}
"""
```